### PR TITLE
resamp2_interpolator typo

### DIFF
--- a/blocks/resamp2.yaml
+++ b/blocks/resamp2.yaml
@@ -86,6 +86,6 @@ resamp2_interpolator:
         y:
             reserve: 2
     work:
-        calls: decim_execute(x, y)
+        calls: interp_execute(x, y)
         mode: STANDARD_LOOP
         interp: 2

--- a/blocks/resamp2.yaml
+++ b/blocks/resamp2.yaml
@@ -88,4 +88,4 @@ resamp2_interpolator:
     work:
         calls: decim_execute(x, y)
         mode: STANDARD_LOOP
-        ionterp: 2
+        interp: 2


### PR DESCRIPTION
This little typo was keeping the half-band interpolator from working properly.